### PR TITLE
fix: avoid compilation warnings array with empty items (WellKnownErrorsPlugin)

### DIFF
--- a/packages/next/src/build/webpack/plugins/wellknown-errors-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/wellknown-errors-plugin/index.ts
@@ -14,7 +14,7 @@ export class WellKnownErrorsPlugin {
                 warn.name === 'ModuleDependencyWarning' &&
                 warn.module.context?.includes('node_modules')
               ) {
-                delete compilation.warnings[i]
+                compilation.warnings.splice( i, 1 )
               }
             })
           )


### PR DESCRIPTION
Currently, when a webpack compilation warning is processed by `WellKnownErrorsPlugin` and it's indeed a well know error that should be bypassed, the warning item is simply deleted from the array, which will produce an array with empty items:

Example:
```js
{
  client: {
    loading: false,
    totalModulesCount: 2172,
    errors: null,
    warnings: [ <1 empty item> ]
  },
  server: {
    loading: false,
    totalModulesCount: 2119,
    errors: null,
    warnings: [ <1 empty item> ]
  },
  edgeServer: {
    loading: false,
    totalModulesCount: 58,
    errors: null,
    warnings: null
  },
  trigger: undefined,
  amp: {}
}
```

This array with empty items generates a side effect on the [build output](https://github.com/vercel/next.js/blob/3553c6516d7a9aba98876f9660af0ee7c94dc2a3/packages/next/src/build/output/store.ts#L124), since the `warning` array has empty items:

```
➤ npm run dev

> next dev

   ▲ Next.js 14.0.1-canary.3
   - Local:        http://localhost:3000
   - Environments: .env.development

 ✓ Ready in 2.6s
 ✓ Compiled /middleware in 109ms (58 modules)
 ○ Compiling /(dashboard)/page ...
 ⚠


 ⚠
```
![CleanShot 2023-10-30 at 13 20 42@2x](https://github.com/luismulinari/next.js/assets/33168/86dbf7b6-4660-4459-bc1d-0d9d7e71a0ed)

This PR solves this issue by removing the `warning` item using the `Array.prototype.splice`, which removes the item instead of making the array position empty.

Related PR: https://github.com/vercel/next.js/pull/57073